### PR TITLE
Fix event to work with other plugins

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ module.exports = function() {
   var args = Array.prototype.slice.call(arguments);
 
   return function(style){
-    style.on('end', function(css, cb){
-      if (args) return cb(null, autoprefixer.apply(this, args).compile(css));
-      cb(null, autoprefixer.compile(css));
+    this.on('end', function(err, css){
+      if (args) return autoprefixer.apply(this, args).compile(css);
+      autoprefixer.compile(css);
     });
   }
 


### PR DESCRIPTION
Now it works well with [csso-stylus](https://github.com/sapegin/csso-stylus) (I did the same fix there) and should works with other Stylus plugins that filter content.

More info: https://github.com/LearnBoost/stylus/pull/1180
